### PR TITLE
enable legacy OpenSSL provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
If you are using Node.js version 17+ then running npm start is met with an error 
"Error: error:0308010C:digital envelope routines::unsupported"
I fixed it by changing a line in package.json from "start": "react-scripts start" to "start": "react-scripts --openssl-legacy-provider start"
